### PR TITLE
use charCode in Game.handleKeyPress for Firefox compatibility

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -57,9 +57,9 @@
   };
 
   Game.prototype.handleKeypress = function (event) {
-    if (event.keyCode === 32 && this.isActive()) {
+    if (event.charCode === 32 && this.isActive()) {
       this.pause();
-    } else if (event.keyCode === 32) {
+    } else if (event.charCode === 32) {
       this.step();
     }
   };
@@ -160,14 +160,6 @@
     this.displayLoss();
     this.newGameListener = this.newGame.bind(this);
     window.addEventListener("keypress", this.newGameListener);
-  };
-
-  Game.prototype.handleKeypress = function (event) {
-    if (event.keyCode === 32 && this.isActive()) {
-      this.pause();
-    } else if (event.keyCode === 32) {
-      this.step();
-    }
   };
 
   Game.prototype.displayLoss = function () {


### PR DESCRIPTION
Given a keypress event, Chrome provides the value of the key through the event object as both keyCode and charCode, but Firefox only uses keyCode for non-printing characters.

Also, having two identical Game.prototype.handleKeypress functions is bad for debugging.
